### PR TITLE
Quick Fix for Null Exception

### DIFF
--- a/app/src/main/java/com/osucse/wayfinding_osu_capstone/Settings.java
+++ b/app/src/main/java/com/osucse/wayfinding_osu_capstone/Settings.java
@@ -91,6 +91,9 @@ public class Settings extends ActionBarActivity {
     }
 
     public static boolean getVisualSetting () {
+        if (settings == null) {
+            return false;
+        }
         return settings.getBoolean(VISUALLY_IMPAIRED, false);
     }
 }


### PR DESCRIPTION
A simple error had made it through our testing with the Visually Impaired code.  If the Settings page had never been visited, then asking for its settings lead to a null pointer exception.  I added a simple null check to return false (our default setting) if settings was null.  This is probably not the permanent or best fix, but it is the fastest and fixes the master branch for the time being.
