### PR TITLE
Way 78 keep map portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,9 @@
         <activity
             android:name=".DisplayMapActivity"
             android:label="@string/title_activity_display_map"
-            android:parentActivityName=".Selection" >
+            android:parentActivityName=".Selection"
+            android:screenOrientation="portrait"
+            android:configChanges="keyboardHidden|orientation|screenSize" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.osucse.wayfinding_osu_capstone.Selection" />

--- a/app/src/main/java/com/osucse/wayfinding_osu_capstone/DisplayMapActivity.java
+++ b/app/src/main/java/com/osucse/wayfinding_osu_capstone/DisplayMapActivity.java
@@ -91,8 +91,6 @@ public class DisplayMapActivity extends FragmentActivity implements SensorEventL
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // Set and lock orientation to portrait
-        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         setContentView(R.layout.activity_display_map);
         Intent intent = getIntent();
 


### PR DESCRIPTION
Sets Map Activity to always be in portrait view.  It does this by making these settings in the Manifest file.
